### PR TITLE
updated ethernet-interfaces.j2

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
@@ -118,6 +118,8 @@ interface {{ ethernet_interface }}
 {%         endif %}
 {%         if ethernet_interfaces[ethernet_interface].spanning_tree_bpduguard is arista.avd.defined(true) %}
    spanning-tree bpduguard enable
+{%         elif ethernet_interfaces[ethernet_interface].spanning_tree_bpduguard is arista.avd.defined(false) %}
+   spanning-tree bpduguard disable
 {%         endif %}
 {%         if ethernet_interfaces[ethernet_interface].vrf is arista.avd.defined %}
    vrf {{ ethernet_interfaces[ethernet_interface].vrf }}
@@ -276,6 +278,26 @@ interface {{ ethernet_interface }}
 {%     if ethernet_interfaces[ethernet_interface].transceiver.media.override is arista.avd.defined %}
    transceiver media override {{ ethernet_interfaces[ethernet_interface].transceiver.media.override }}
 {%     endif %}
+{%         if ethernet_interfaces[ethernet_interface].error_correction_encoding.enabled is arista.avd.defined(true) %}
+{%                if ethernet_interfaces[ethernet_interface].error_correction_encoding.fire_code is arista.avd.defined(true) %}
+   error-correction encoding fire-code
+{%                elif ethernet_interfaces[ethernet_interface].error_correction_encoding.fire_code is arista.avd.defined(false) %}
+   no error-correction encoding fire-code
+{%                elif ethernet_interfaces[ethernet_interface].error_correction_encoding.fire_code is arista.avd.defined('default') %}
+   default error-correction encoding fire-code
+{%                endif %}
+{%                if ethernet_interfaces[ethernet_interface].error_correction_encoding.reed_solomon is arista.avd.defined(true) %}
+   error-correction encoding reed-solomon
+{%                elif ethernet_interfaces[ethernet_interface].error_correction_encoding.reed_solomon is arista.avd.defined(false) %}
+   no error-correction encoding reed-solomon
+{%                elif ethernet_interfaces[ethernet_interface].error_correction_encoding.reed_solomon is arista.avd.defined('default') %}
+   default error-correction encoding reed-solomon
+{%                endif %}
+{%         elif ethernet_interfaces[ethernet_interface].error_correction_encoding.enabled is arista.avd.defined(false) %}
+   no error-correction encoding
+{%         elif ethernet_interfaces[ethernet_interface].error_correction_encoding.enabled is arista.avd.defined('default') %}
+   default error-correction encoding
+{%         endif %}
 {%     if ethernet_interfaces[ethernet_interface].eos_cli is arista.avd.defined %}
    {{ ethernet_interfaces[ethernet_interface].eos_cli | indent(3, false) }}
 {%     endif %}


### PR DESCRIPTION
## Change Summary

add possibility to set spanning_tree_bpduguard to false

1- Currently, the ethernet template has the functionality spanning_tree_bpduguard: < true | false > but in reality, it only supports the value true which enables the spanning_tree_bpduguard, but disabling it doesn't work.

2- The error-correction encoding command is currently not supported.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

Fixes #1105
Fixes #1079

## Component(s) name

`arista.avd.eos_cli_config_gen`


## Proposed changes

### ethernet-interfaces.j2

`{% if ethernet_interfaces[ethernet_interface].spanning_tree_bpduguard is arista.avd.defined(true) %}`
`spanning-tree bpduguard enable`
`{% elif ethernet_interfaces[ethernet_interface].spanning_tree_bpduguard is arista.avd.defined(false) %}`
`spanning-tree bpduguard disable`
`{% endif %}`
...
`{%         if ethernet_interfaces[ethernet_interface].error_correction_encoding.enabled is arista.avd.defined(true) %}`
`{%                if ethernet_interfaces[ethernet_interface].error_correction_encoding.fire_code is arista.avd.defined(true) %}`
`   error-correction encoding fire-code`
`{%                elif ethernet_interfaces[ethernet_interface].error_correction_encoding.fire_code is arista.avd.defined(false) %}`
`   no error-correction encoding fire-code`
`{%                elif ethernet_interfaces[ethernet_interface].error_correction_encoding.fire_code is arista.avd.defined('default') %}`
`   default error-correction encoding fire-code`
`{%                endif %}`
`{%                if ethernet_interfaces[ethernet_interface].error_correction_encoding.reed_solomon is arista.avd.defined(true) %}`
`   error-correction encoding reed-solomon`
`{%                elif ethernet_interfaces[ethernet_interface].error_correction_encoding.reed_solomon is arista.avd.defined(false) %}`
`   no error-correction encoding reed-solomon`
`{%                elif ethernet_interfaces[ethernet_interface].error_correction_encoding.reed_solomon is arista.avd.defined('default')%}`
`   default error-correction encoding reed-solomon`
`{%                endif %}`
`{%         elif ethernet_interfaces[ethernet_interface].error_correction_encoding.enabled is arista.avd.defined(false) %}`
`   no error-correction encoding`
`{%         elif ethernet_interfaces[ethernet_interface].error_correction_encoding.enabled is arista.avd.defined('default') %}`
`   default error-correction encoding`
`{%         endif %}`



New Schema:

```yaml
error_correction_encoding:
    enabled: < true | false | default >
    fire_code: < true | false | default >
    reed_solomon: < true | false | default >
```



## How to test
generate sample using ansible with role, with the two scenarios (False/true)

## Checklist:
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [ ] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
